### PR TITLE
hotfix for refresh filter function on result view

### DIFF
--- a/tracex/extraction/views.py
+++ b/tracex/extraction/views.py
@@ -169,7 +169,7 @@ class ResultView(generic.FormView):
         activity_key="event_type",
     ):
         """Create the xes file for the single journey."""
-        if not is_test or is_extracted:
+        if not (is_test or is_extracted):
             output_path_csv = input_handling.convert_text_to_csv(journey)
             output_path_xes = create_xes.create_xes(
                 output_path_csv, name=xes_name, key=activity_key
@@ -188,7 +188,7 @@ class ResultView(generic.FormView):
         activity_key="event_type",
     ):
         """Create the xes file for all journeys."""
-        if not is_test or is_extracted:
+        if not (is_test or is_extracted):
             output_handling.append_csv()
             all_traces_xes_path = create_xes.create_xes(
                 utils.CSV_ALL_TRACES, name=xes_name, key=activity_key


### PR DESCRIPTION
Due to a minor logical error the pipeline reran everytime the "Refresh Filter" option was used.
This is fixed by adding paranthesis to an if-condition.