### PR TITLE
Fix environment variable issue in `main.py`

### DIFF
--- a/commandLineTool.py
+++ b/commandLineTool.py
@@ -1,5 +1,9 @@
 """Module providing the main function."""
 
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tracex.tracex.settings")
+
 from tracex.extraction.prototype import input_inquiry as ii
 from tracex.extraction.prototype import input_handling as ih
 from tracex.extraction.prototype import output_handling as oh

--- a/command_line_tool.py
+++ b/command_line_tool.py
@@ -1,8 +1,9 @@
 """Module providing the main function."""
-
+# pylint: disable=wrong-import-position
 import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tracex.tracex.settings")
+# pylint: enable=wrong-import-position
 
 from tracex.extraction.prototype import input_inquiry as ii
 from tracex.extraction.prototype import input_handling as ih


### PR DESCRIPTION
So far the `DJANGO_SETTINGS_MODULE` environment variable needed to be set manually. By moving `main.py` outside the django scope that is no longer an issue, because the variable can now be set inside the script.
Furthermore the file was renamed to `command_line_tool.py` with is a more descriptive name.

The pylint check `wrong-import-position`needs to be disabled for this file partially, since there is no other way to order the imports, but pylint doesn't understand that unfortunately.