### PR TITLE
Feature: capability to download traces (single and all traces) from tracex

### DIFF
--- a/tracex_project/extraction/templates/result.html
+++ b/tracex_project/extraction/templates/result.html
@@ -87,6 +87,24 @@
         <input type="submit" value="Refresh Filter" class="button">
     </form>
 
+    <p style="margin-bottom: 0"><b>Choose the XES file to download:</b></p><br>
+    <form action="{% url 'download_xes' %}" method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+
+        <div class="form-row">
+            <div class="form-column">
+                <input type="radio" id="single_trace" name="trace_type" value="single_trace" class="trace-radio">
+                <label for="single_trace">Single Trace XES</label>
+            </div>
+            <div class="form-column">
+                <input type="radio" id="all_traces" name="trace_type" value="all_traces" checked class="trace-radio">
+                <label for="all_traces">All Traces XES</label>
+            </div>
+        </div>
+
+        <input type="submit" value="Download Selected XES File" class="button">
+    </form>
+
     <a href="{% url 'save_success' %}">
         <button class="menu_button">Save results to the database</button>
     </a>

--- a/tracex_project/extraction/urls.py
+++ b/tracex_project/extraction/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('download-xes/', views.download_xes, name='download_xes'),
     path("extraction/", views.JourneyInputView.as_view(), name="journey_input"),
     path("extraction/result/", views.ResultView.as_view(), name="result"),
     path(


### PR DESCRIPTION
Hello, we now have the capability to download traces either as single or all traces as XES files. 
This allows us to save them locally and use them with various programs, such as Disko, for further analysis.

I added a button (as a form) to our result view, where you can either choose between single trace or all traces.
In my screenshot highlighted in the red box.

![image](https://github.com/bptlab/TracEX/assets/105175491/01df51f5-00f4-40f4-926b-b07b07783b8b)


