### PR TITLE
Refactoring: Fixing the df warnings to be able to use Pandas 3.0 in the future

### DIFF
--- a/tracex_project/extraction/logic/modules/module_time_extractor.py
+++ b/tracex_project/extraction/logic/modules/module_time_extractor.py
@@ -94,12 +94,12 @@ class TimeExtractor(Module):
         )
         mask = converted_start.isna()
         df.loc[mask, "start"] = converted_start
-        df["start"] = df["start"].ffill()  # Modified to avoid using inplace=True
+        df["start"] = df["start"].ffill()
 
         converted_end = pd.to_datetime(df["end"], format="%Y%m%dT%H%M", errors="coerce")
         mask = converted_end.isna()
         df.loc[mask, "end"] = converted_end
-        df["end"] = df["end"].ffill()  # Modified to avoid using inplace=True
+        df["end"] = df["end"].ffill()
 
         df = df.apply(fix_end_dates, axis=1)
 

--- a/tracex_project/extraction/logic/modules/module_time_extractor.py
+++ b/tracex_project/extraction/logic/modules/module_time_extractor.py
@@ -94,12 +94,12 @@ class TimeExtractor(Module):
         )
         mask = converted_start.isna()
         df.loc[mask, "start"] = converted_start
-        df["start"].ffill(inplace=True)
+        df["start"] = df["start"].ffill()  # Modified to avoid using inplace=True
 
         converted_end = pd.to_datetime(df["end"], format="%Y%m%dT%H%M", errors="coerce")
         mask = converted_end.isna()
         df.loc[mask, "end"] = converted_end
-        df["end"].ffill(inplace=True)
+        df["end"] = df["end"].ffill()  # Modified to avoid using inplace=True
 
         df = df.apply(fix_end_dates, axis=1)
 


### PR DESCRIPTION
Hi, 

I fixed the warnings which was stated from our PO in #92.
We can now use Pandas 3.0 if we want to.

Changes:

Removing inplace=True and using direct assignment avoids operations on temporary objects, ensuring changes affect the original DataFrame. Directly assigning the result of ffill() to DataFrame columns clarifies the intent and ensures that modifications are applied where expected.
These changes future-proof the code against upcoming changes in pandas which would change the inplace method

This PR closes #92.



