### PR TITLE
Feature: GPT Key Request on the landing page

### DIFF
--- a/tracex_project/tracex/forms.py
+++ b/tracex_project/tracex/forms.py
@@ -1,3 +1,4 @@
+"""Implementation of forms"""
 from django import forms
 
 

--- a/tracex_project/tracex/forms.py
+++ b/tracex_project/tracex/forms.py
@@ -2,6 +2,7 @@ from django import forms
 
 
 class ApiKeyForm(forms.Form):
+    """A form for inputting the OpenAI API key."""
     api_key = forms.CharField(
         label='Enter your OpenAI API Key',
         max_length=100,

--- a/tracex_project/tracex/forms.py
+++ b/tracex_project/tracex/forms.py
@@ -1,0 +1,17 @@
+from django import forms
+
+
+class ApiKeyForm(forms.Form):
+    api_key = forms.CharField(
+        label='Enter your OpenAI API Key',
+        max_length=100,
+        widget=forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'API Key'})
+    )
+
+    def clean_api_key(self):
+        """Check if API Key formation is valid."""
+        api_key = self.cleaned_data.get('api_key')
+        if not api_key or len(api_key.strip()) == 0:
+            raise forms.ValidationError("API Key cannot be empty.")
+
+        return api_key

--- a/tracex_project/tracex/static/tracex/css/style.css
+++ b/tracex_project/tracex/static/tracex/css/style.css
@@ -339,3 +339,30 @@ text-align: center;
     text-decoration: none;
     cursor: pointer;
 }
+
+.modal-backdrop {
+    z-index: 1040; /* or lower than modal if modal needs to be on top */
+}
+
+.modal {
+    z-index: 1050; /* higher than modal-backdrop */
+}
+
+/* Default width */
+#apiKeyModal .modal-dialog {
+    max-width: 90%; /* Use a high percentage for smaller screens */
+}
+
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) {
+    #apiKeyModal .modal-dialog {
+        max-width: 70%; /* Slightly smaller percentage for medium screens */
+    }
+}
+
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) {
+    #apiKeyModal .modal-dialog {
+        max-width: 50%; /* Even smaller for large screens */
+    }
+}

--- a/tracex_project/tracex/static/tracex/js/forms_open_ai_key.js
+++ b/tracex_project/tracex/static/tracex/js/forms_open_ai_key.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+    window.addEventListener('load', function () {
+        var forms = document.getElementsByClassName('needs-validation');
+        Array.prototype.filter.call(forms, function (form) {
+            form.addEventListener('submit', function (event) {
+                if (!form.checkValidity()) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+                form.classList.add('was-validated');
+            }, false);
+        });
+    });
+})();
+
+$(document).ready(function() {
+    $('#apiKeyModal').modal('show');
+});

--- a/tracex_project/tracex/templates/landing_page.html
+++ b/tracex_project/tracex/templates/landing_page.html
@@ -37,33 +37,36 @@
             </div>
         </div>
     </div>
-    {% if prompt_for_key %}
-    <div class="modal fade" id="apiKeyModal" tabindex="-1" role="dialog"
-         aria-labelledby="apiKeyModalLabel" aria-hidden="true"
-         data-backdrop="static" data-keyboard="false">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="apiKeyModalLabel">API Key Needed</h5>
-                </div>
-                <div class="modal-body">
-                    <form method="post" action="{% url 'set_api_key' %}" class="needs-validation" novalidate>
-                        {% csrf_token %}
-                        <div class="form-group">
-                            <label for="api_key">Enter your OpenAI API Key</label>
-                            <input type="text" class="form-control" id="api_key" name="api_key" placeholder="API Key" required>
-                            <div class="invalid-feedback">
-                                Please provide an API Key.
-                            </div>
+   {% if prompt_for_key %}
+<div class="modal fade" id="apiKeyModal" tabindex="-1" role="dialog" aria-labelledby="apiKeyModalLabel" aria-hidden="true" data-backdrop="static" data-keyboard="false">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="apiKeyModalLabel">API Key Needed</h5>
+            </div>
+            <div class="modal-body">
+                <form method="post" action="" class="needs-validation" novalidate>
+                    {% csrf_token %}
+                    <div class="form-group">
+                        <label for="api_key">Enter your OpenAI API Key</label>
+                        <input type="text" class="form-control" id="api_key" name="api_key" placeholder="API Key" required>
+                        <div class="invalid-feedback">
+                            Please provide an API Key.
                         </div>
-                        <div class="modal-footer">
-                            <button type="submit" class="btn btn-primary">Save API Key</button>
-                        </div>
-                    </form>
-                </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="submit" class="btn btn-primary">Save API Key</button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>
-    {% endif %}
+</div>
+<script>
+    $(document).ready(function(){
+        $('#apiKeyModal').modal('show');
+    });
+</script>
+{% endif %}
 </body>
 </html>

--- a/tracex_project/tracex/templates/landing_page.html
+++ b/tracex_project/tracex/templates/landing_page.html
@@ -55,7 +55,7 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="submit" class="btn btn-primary">Save API Key</button>
+                        <button type="submit" class="btn btn-secondary">Save API Key</button>
                     </div>
                 </form>
             </div>

--- a/tracex_project/tracex/templates/landing_page.html
+++ b/tracex_project/tracex/templates/landing_page.html
@@ -3,22 +3,27 @@
 <head>
     <title>TracEX</title>
     {% load static %}
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="{% static '/tracex/css/style.css' %}">
+    <script src="{% static '/tracex/js/forms_open_ai_key.js' %}"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.min.js"></script>
 </head>
-
 <body class="landing_page_body">
     <div class="landing_page_container">
         <img src="{% static '/tracex/img/TraceEx_v2.svg' %}" alt="TracEX Logo" class="landing_page_logo">
         <div class="landing_page_menu">
             <div class="item patient_journey_generator">
                 <a href="{% url 'journey_generator_overview' %}">
-                <img src="{% static '/tracex/img/patient_journey_generator_logo.png' %}" alt="Patient Journey Generator Logo" class="patient_journey_generator_logo">
-                <span class="item_text">Patient Journey Generator</span>
+                    <img src="{% static '/tracex/img/patient_journey_generator_logo.png' %}" alt="Patient Journey Generator Logo" class="patient_journey_generator_logo">
+                    <span class="item_text">Patient Journey Generator</span>
+                </a>
             </div>
             <div class="item extraction">
                 <a href="{% url 'journey_input' %}">
-                <img src="{% static '/tracex/img/extraction_logo.png' %}" alt="Extraction Logo" class="extraction_logo">
-                <span class="item_text">Extraction Pipeline</span> </a>
+                    <img src="{% static '/tracex/img/extraction_logo.png' %}" alt="Extraction Logo" class="extraction_logo">
+                    <span class="item_text">Extraction Pipeline</span>
+                </a>
             </div>
             <div class="item result_dashboard">
                 <img src="{% static '/tracex/img/result_dashboard_logo.png' %}" alt="Result Dashboard Logo" class="result_dashboard_logo">
@@ -26,12 +31,39 @@
             </div>
             <div class="item testing_environment">
                 <a href="{% url 'testing_environment' %}">
-                <img src="{% static '/tracex/img/test_environment_logo.png' %}" alt="Test Environment Logo" class="test_environment_logo">
-                <span class="item_text">Trace Testing Environment</span>
+                    <img src="{% static '/tracex/img/test_environment_logo.png' %}" alt="Test Environment Logo" class="test_environment_logo">
+                    <span class="item_text">Trace Testing Environment</span>
                 </a>
             </div>
-
         </div>
     </div>
+    {% if prompt_for_key %}
+    <div class="modal fade" id="apiKeyModal" tabindex="-1" role="dialog"
+         aria-labelledby="apiKeyModalLabel" aria-hidden="true"
+         data-backdrop="static" data-keyboard="false">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="apiKeyModalLabel">API Key Needed</h5>
+                </div>
+                <div class="modal-body">
+                    <form method="post" action="{% url 'set_api_key' %}" class="needs-validation" novalidate>
+                        {% csrf_token %}
+                        <div class="form-group">
+                            <label for="api_key">Enter your OpenAI API Key</label>
+                            <input type="text" class="form-control" id="api_key" name="api_key" placeholder="API Key" required>
+                            <div class="invalid-feedback">
+                                Please provide an API Key.
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="submit" class="btn btn-primary">Save API Key</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 </body>
 </html>

--- a/tracex_project/tracex/urls.py
+++ b/tracex_project/tracex/urls.py
@@ -7,6 +7,7 @@ from . import views
 
 urlpatterns = [
     path("", include("patient_journey_generator.urls")),
+    path("set-api-key/", views.set_api_key, name="set_api_key"),
     path("", include("extraction.urls")),
     path("", include("trace_comparator.urls")),
     path("", views.TracexLandingPage.as_view(), name="landing_page"),

--- a/tracex_project/tracex/urls.py
+++ b/tracex_project/tracex/urls.py
@@ -7,7 +7,6 @@ from . import views
 
 urlpatterns = [
     path("", include("patient_journey_generator.urls")),
-    path("set-api-key/", views.set_api_key, name="set_api_key"),
     path("", include("extraction.urls")),
     path("", include("trace_comparator.urls")),
     path("", views.TracexLandingPage.as_view(), name="landing_page"),

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -17,7 +17,7 @@ class TracexLandingPage(TemplateView):
 
         return self.render_to_response(context)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request):
         """Handles POST requests by processing a submitted form containing an API key.
         If valid, saves the API key to the environment and redirects to the landing page;
         otherwise, renders the form with errors."""

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -9,7 +9,7 @@ class TracexLandingPage(TemplateView):
     """View for the landing page of the tracex app."""
     template_name = "landing_page.html"
 
-    def get(self, _request, *args, **kwargs):
+    def get(self, _request, *_args, **kwargs):
         """Handles GET requests by initializing a form for API key entry and adding it to the context."""
         form = ApiKeyForm()
         context = self.get_context_data(**kwargs)

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -1,36 +1,32 @@
-"""This file contains the views for the landing page of the tracex app."""
 from django.views.generic import TemplateView
 from django.shortcuts import render, redirect
 from .forms import ApiKeyForm
 import os
 
-
 class TracexLandingPage(TemplateView):
-    """View for the landing page of the tracex app."""
-
     template_name = "landing_page.html"
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        self.request.session.flush()
-        api_key = os.getenv('OPENAI_API_KEY')
-        print("API Key:", api_key)
-        context['prompt_for_key'] = not bool(api_key)
-        context['form'] = ApiKeyForm()
-        return context
+    def get(self, request, *args, **kwargs):
+        form = ApiKeyForm()
+        context = self.get_context_data(**kwargs)
+        context['form'] = form
+        return self.render_to_response(context)
 
-
-def set_api_key(request):
-    if request.method == 'POST':
+    def post(self, request, *args, **kwargs):
         form = ApiKeyForm(request.POST)
         if form.is_valid():
             api_key = form.cleaned_data['api_key']
-            os.environ['OPENAI_API_KEY'] = api_key
-
+            os.environ['OPENAI_API_KEY'] = api_key  # This sets it for the current process only
             return redirect('landing_page')
         else:
+            return render(request, self.template_name, {'form': form})
 
-            return render(request, 'landing_page', {'form': form})
-    else:
-        form = ApiKeyForm()
-    return render(request, 'landing_page', {'form': form})
+    # Adjust the get_context_data method in your TracexLandingPage class:
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        api_key = os.getenv('OPENAI_API_KEY')
+        print(api_key)
+        context['prompt_for_key'] = not bool(api_key)
+        print(context['prompt_for_key'])
+        return context
+

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -1,8 +1,8 @@
 """This file contains the views for the landing page of the tracex app."""
+import os
 from django.views.generic import TemplateView
 from django.shortcuts import render, redirect
 from .forms import ApiKeyForm
-import os
 
 
 class TracexLandingPage(TemplateView):

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -35,6 +35,7 @@ class TracexLandingPage(TemplateView):
         """Retrieves and returns the base context data enhanced with the presence check for the API key.
         Indicates if a prompt for the API key is needed based on its absence."""
         context = super().get_context_data(**kwargs)
+        self.request.session.flush()
         api_key = os.getenv('OPENAI_API_KEY')
         context['prompt_for_key'] = not bool(api_key)
 

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -16,6 +16,11 @@ class TracexLandingPage(TemplateView):
         return self.render_to_response(context)
 
     def post(self, request, *args, **kwargs):
+        """
+        Handles POST requests by processing a submitted form containing an API key.
+        If valid, saves the API key to the environment and redirects to the landing page;
+        otherwise, renders the form with errors.
+        """
         form = ApiKeyForm(request.POST)
         if form.is_valid():
             api_key = form.cleaned_data['api_key']

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -16,11 +16,9 @@ class TracexLandingPage(TemplateView):
         return self.render_to_response(context)
 
     def post(self, request, *args, **kwargs):
-        """
-        Handles POST requests by processing a submitted form containing an API key.
+        """Handles POST requests by processing a submitted form containing an API key.
         If valid, saves the API key to the environment and redirects to the landing page;
-        otherwise, renders the form with errors.
-        """
+        otherwise, renders the form with errors."""
         form = ApiKeyForm(request.POST)
         if form.is_valid():
             api_key = form.cleaned_data['api_key']
@@ -32,6 +30,8 @@ class TracexLandingPage(TemplateView):
             return render(request, self.template_name, {'form': form})
 
     def get_context_data(self, **kwargs):
+        """Retrieves and returns the base context data enhanced with the presence check for the API key.
+        Indicates if a prompt for the API key is needed based on its absence."""
         context = super().get_context_data(**kwargs)
         api_key = os.getenv('OPENAI_API_KEY')
         print(api_key)

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -1,5 +1,8 @@
 """This file contains the views for the landing page of the tracex app."""
 from django.views.generic import TemplateView
+from django.shortcuts import render, redirect
+from .forms import ApiKeyForm
+import os
 
 
 class TracexLandingPage(TemplateView):
@@ -8,8 +11,26 @@ class TracexLandingPage(TemplateView):
     template_name = "landing_page.html"
 
     def get_context_data(self, **kwargs):
-        """Reset session variables."""
         context = super().get_context_data(**kwargs)
         self.request.session.flush()
-
+        api_key = os.getenv('OPENAI_API_KEY')
+        print("API Key:", api_key)
+        context['prompt_for_key'] = not bool(api_key)
+        context['form'] = ApiKeyForm()
         return context
+
+
+def set_api_key(request):
+    if request.method == 'POST':
+        form = ApiKeyForm(request.POST)
+        if form.is_valid():
+            api_key = form.cleaned_data['api_key']
+            os.environ['OPENAI_API_KEY'] = api_key
+
+            return redirect('landing_page')
+        else:
+
+            return render(request, 'landing_page', {'form': form})
+    else:
+        form = ApiKeyForm()
+    return render(request, 'landing_page', {'form': form})

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -34,8 +34,6 @@ class TracexLandingPage(TemplateView):
         Indicates if a prompt for the API key is needed based on its absence."""
         context = super().get_context_data(**kwargs)
         api_key = os.getenv('OPENAI_API_KEY')
-        print(api_key)
         context['prompt_for_key'] = not bool(api_key)
-        print(context['prompt_for_key'])
 
         return context

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -9,11 +9,12 @@ class TracexLandingPage(TemplateView):
     """View for the landing page of the tracex app."""
     template_name = "landing_page.html"
 
-    def get(self, request, *_args, **kwargs):
+    def get(self, _request, *args, **kwargs):
         """Handles GET requests by initializing a form for API key entry and adding it to the context."""
         form = ApiKeyForm()
         context = self.get_context_data(**kwargs)
         context['form'] = form
+
         return self.render_to_response(context)
 
     def post(self, request):
@@ -35,4 +36,5 @@ class TracexLandingPage(TemplateView):
         self.request.session.flush()
         api_key = os.getenv('OPENAI_API_KEY')
         context['prompt_for_key'] = not bool(api_key)
+
         return context

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -1,3 +1,4 @@
+"""This file contains the views for the landing page of the tracex app."""
 from django.views.generic import TemplateView
 from django.shortcuts import render, redirect
 from .forms import ApiKeyForm
@@ -5,6 +6,7 @@ import os
 
 
 class TracexLandingPage(TemplateView):
+    """View for the landing page of the tracex app."""
     template_name = "landing_page.html"
 
     def get(self, request, *args, **kwargs):

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import render, redirect
 from .forms import ApiKeyForm
 import os
 
+
 class TracexLandingPage(TemplateView):
     template_name = "landing_page.html"
 
@@ -10,6 +11,7 @@ class TracexLandingPage(TemplateView):
         form = ApiKeyForm()
         context = self.get_context_data(**kwargs)
         context['form'] = form
+
         return self.render_to_response(context)
 
     def post(self, request, *args, **kwargs):
@@ -17,16 +19,17 @@ class TracexLandingPage(TemplateView):
         if form.is_valid():
             api_key = form.cleaned_data['api_key']
             os.environ['OPENAI_API_KEY'] = api_key  # This sets it for the current process only
+
             return redirect('landing_page')
         else:
+
             return render(request, self.template_name, {'form': form})
 
-    # Adjust the get_context_data method in your TracexLandingPage class:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         api_key = os.getenv('OPENAI_API_KEY')
         print(api_key)
         context['prompt_for_key'] = not bool(api_key)
         print(context['prompt_for_key'])
-        return context
 
+        return context

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -8,6 +8,7 @@ class TracexLandingPage(TemplateView):
     template_name = "landing_page.html"
 
     def get(self, request, *args, **kwargs):
+        """Handles GET requests by initializing a form for API key entry and adding it to the context."""
         form = ApiKeyForm()
         context = self.get_context_data(**kwargs)
         context['form'] = form

--- a/tracex_project/tracex/views.py
+++ b/tracex_project/tracex/views.py
@@ -9,12 +9,11 @@ class TracexLandingPage(TemplateView):
     """View for the landing page of the tracex app."""
     template_name = "landing_page.html"
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *_args, **kwargs):
         """Handles GET requests by initializing a form for API key entry and adding it to the context."""
         form = ApiKeyForm()
         context = self.get_context_data(**kwargs)
         context['form'] = form
-
         return self.render_to_response(context)
 
     def post(self, request):
@@ -25,11 +24,9 @@ class TracexLandingPage(TemplateView):
         if form.is_valid():
             api_key = form.cleaned_data['api_key']
             os.environ['OPENAI_API_KEY'] = api_key  # This sets it for the current process only
-
             return redirect('landing_page')
-        else:
 
-            return render(request, self.template_name, {'form': form})
+        return render(request, self.template_name, {'form': form})
 
     def get_context_data(self, **kwargs):
         """Retrieves and returns the base context data enhanced with the presence check for the API key.
@@ -38,5 +35,4 @@ class TracexLandingPage(TemplateView):
         self.request.session.flush()
         api_key = os.getenv('OPENAI_API_KEY')
         context['prompt_for_key'] = not bool(api_key)
-
         return context


### PR DESCRIPTION
Hi,
I have added a feature that checks if there is an Open API key in the environment variables. If not, a popup appears forcing the user to enter an API key in order to use TracEX. 
![image](https://github.com/bptlab/TracEX/assets/105175491/6190f555-651d-443b-800f-65d409278ef0)

If a user submits an empty string, an error message in red will appear, indicating that input is required.
![image](https://github.com/bptlab/TracEX/assets/105175491/d6752fbc-27b3-4285-b75c-21c9c0463cbc)

I've designed the code to be easily extendable for future validations, such as verifying whether a key is a valid open API key, checking if it still has tokens available, or ensuring it meets specific length requirements.

This PR closes #87.